### PR TITLE
fix: expand button position

### DIFF
--- a/src/app/bn-table/styles/index.less
+++ b/src/app/bn-table/styles/index.less
@@ -69,11 +69,11 @@
       appearance: none;
       border: 1px solid;
       border-radius: 8px;
-      margin-left: 0.5rem;
       cursor: pointer;
       color: @primary-100;
       border-color: @primary-60;
       background-color: transparent;
+      float: right;
     }
 
     .@{components-prefix}-showmore-on {


### PR DESCRIPTION
This should do the job of right-aligning the button in a table cell, but it's not a very good way to solve the problem.
I suggest that you make this property an input, so the button can be positioned before or after the content.